### PR TITLE
Removed an unnecessary call to Keyword.get.

### DIFF
--- a/lib/kaguya/channel.ex
+++ b/lib/kaguya/channel.ex
@@ -118,8 +118,7 @@ defmodule Kaguya.Channel do
   def handle_call(:get_user_count, _from, {_name, users, _buffer} = state) do
     count =
       users
-      |> :ets.info
-      |> Keyword.get(:size)
+      |> :ets.info(:size)
     {:reply, count, state}
   end
 


### PR DESCRIPTION
http://erldocs.com/current/stdlib/ets.html?i=3&search=ets:info#info/2
:ets.info/2 can be used to get specific values.
