### PR TITLE
Remove unused Behaviour and raise exception on incomplete config

### DIFF
--- a/lib/kaguya.ex
+++ b/lib/kaguya.ex
@@ -6,14 +6,15 @@ defmodule Kaguya do
 
   @doc """
   Starts the bot, checking for proper configuration first.
+
+  Raises exception on incomplete configuration.
   """
   def start(_type, _args) do
     opts = Application.get_all_env(:kaguya)
-    if Enum.all?([:bot_name, :server, :port], fn k -> Keyword.has_key?(opts, k) end) do
-      start_bot
+    if Enum.all?([:bot_name, :server, :port], &(Map.has_key?(opts, &1))) do
+      start_bot()
     else
-      require Logger
-      Logger.log :error, "You must provide configuration options for the server, port, and bot name!"
+      raise "You must provide configuration options for the server, port, and bot name!"
     end
   end
 

--- a/lib/kaguya/module.ex
+++ b/lib/kaguya/module.ex
@@ -3,8 +3,6 @@ defmodule Kaguya.Module do
     defstruct command: "", args: [], trailing: "", user: nil
   end
 
-  use Behaviour
-
   @moduledoc """
   Module which provides functionality used for creating IRC modules.
 

--- a/lib/kaguya/module_supervisor.ex
+++ b/lib/kaguya/module_supervisor.ex
@@ -13,7 +13,7 @@ defmodule Kaguya.ModuleSupervisor do
 
   def init(:ok) do
     Logger.log :debug, "Starting modules!"
-    load_modules
+    load_modules()
     |> Enum.reverse
     |> Enum.map(fn module -> worker(module, []) end)
     |> supervise(strategy: :one_for_one)


### PR DESCRIPTION
A bit of refactoring again.
I missed two warnings.

And i noticed that `Behaviour` wasn't even used in Kaguya.Module.
So i just removed it.
I'm new to Elixir so let me know if it is used somehow...

In addition to that i think it would be better to raise exception on incomplete configuration.
Error in logs is ok, but regardless Kaguya will not be able to work without a proper config so it makes sense to just raise exception.
Or maybe it would better to return `{:error, "You must provide configuration options for the server, port, and bot name!"}`