### PR TITLE
Rejoin channels on reconnect

### DIFF
--- a/lib/kaguya/channel.ex
+++ b/lib/kaguya/channel.ex
@@ -127,6 +127,10 @@ defmodule Kaguya.Channel do
     {:stop, :normal, :ok, nil}
   end
 
+  def handle_call(:join, _from, {name, _users, _buffer}) do
+    Kaguya.Channel.init([name])
+  end
+
   @doc """
   Convnenience function to join the specified channel.
   """

--- a/lib/kaguya/core.ex
+++ b/lib/kaguya/core.ex
@@ -39,13 +39,16 @@ defmodule Kaguya.Core do
   end
 
   def handle_info(:init, state) do
-    Task.start fn ->
-      if password() != nil do
-        Kaguya.Util.sendPass(password())
-      end
-      Kaguya.Util.sendUser(name())
-      Kaguya.Util.sendNick(name())
+    if password() != nil do
+      Kaguya.Util.sendPass(password())
     end
+    Kaguya.Util.sendUser(name())
+    Kaguya.Util.sendNick(name())
+    {:noreply, state}
+  end
+
+  def handle_info(:rejoin_chan, state) do
+    :pg2.get_members(:channels) |> send(:join)
     {:noreply, state}
   end
 
@@ -128,6 +131,7 @@ defmodule Kaguya.Core do
     cancel_server_timer(state)
     socket = reconnect()
     send(self(), :init)
+    send(self(), :rejoin_chan)
     {:noreply, server_timer(%{socket: socket}, server_timeout())}
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
 %{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [repo: "hexpm", hex: :earmark, optional: false]}], "hexpm"}}


### PR DESCRIPTION
So since all channels are having own processes and are accessible through pg2 i thought to just send `:join` to trigger sending of JOIN message.

But do you think maybe it would be better to re-create them anew?