### PR TITLE
Don't crash if use_ssl hasn't been set

### DIFF
--- a/lib/kaguya/core.ex
+++ b/lib/kaguya/core.ex
@@ -138,7 +138,7 @@ defmodule Kaguya.Core do
     Logger.log :debug, "Sending: #{raw_message}"
     case use_ssl() do
       true -> :ssl.send(socket, raw_message)
-      false -> :gen_tcp.send(socket, raw_message)
+      _ -> :gen_tcp.send(socket, raw_message)
     end
   end
 


### PR DESCRIPTION
Latest commit almost immediately crashes Kaguya if the `use_ssl` config key hasn't been set, as `send_message()` in `core.ex` doesn't handle the `nil` case when checking `use_ssl()`. Fixed by changing from `true` to `_`.